### PR TITLE
Work-around to prevent URL-encoded string from getting re-encoded

### DIFF
--- a/src/de/danoeh/antennapodsp/service/download/HttpDownloader.java
+++ b/src/de/danoeh/antennapodsp/service/download/HttpDownloader.java
@@ -28,8 +28,12 @@ public class HttpDownloader extends Downloader {
 
     private URI getURIFromRequestUrl(String source) {
         try {
-            URL url = new URL(source);
-            return new URI(url.getProtocol(), url.getUserInfo(), url.getHost(), url.getPort(), url.getPath(), url.getQuery(), url.getRef());
+            // Single-string URI constructor DE-codes original URL.
+            // Convert URI back to URL (seems silly, but easier than mapping orig url.methods to URI methods.
+            // Switch to uri.getPath() for return statement so de-coded path gets encoded (and not encoded path getting double-encoded).
+            URI uri = new URI(source);
+            URL url = uri.toURL();
+            return new URI(url.getProtocol(), url.getUserInfo(), url.getHost(), url.getPort(), uri.getPath(), url.getQuery(), url.getRef());
         } catch (MalformedURLException e) {
             throw new IllegalArgumentException(e);
         } catch (URISyntaxException e) {


### PR DESCRIPTION
closes #3
- Kludgy work-around:
  - Decode original URL string from podcast feed to restore spaces (or other reserved characters)
  - Cast back to URL in order to get arguments needed for return value
